### PR TITLE
Drop broken Elixir versions

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -81,10 +81,6 @@ in
     inherit (pkgs.stdenv) mkDerivation;
   };
 
-  elixir_1_6_erlangR21 = pkgs.callPackage ./pkgs/elixir/elixir_1_6 {
-    erlang = pkgs.erlangR21;
-  };
-
   # Use the same OTP version as what elixir-ls was built on.
   elixir-ls_1_8 = (pkgs.callPackage ./pkgs/elixir-ls {
     elixir = pkgs.elixir_1_8;

--- a/default.nix
+++ b/default.nix
@@ -81,10 +81,6 @@ in
     inherit (pkgs.stdenv) mkDerivation;
   };
 
-  elixir_1_6_erlangR20 = pkgs.callPackage ./pkgs/elixir/elixir_1_6 {
-    erlang = pkgs.erlangR20;
-  };
-
   elixir_1_6_erlangR21 = pkgs.callPackage ./pkgs/elixir/elixir_1_6 {
     erlang = pkgs.erlangR21;
   };


### PR DESCRIPTION
These versions are no longer available from the upstream nixpkgs.