### PR TITLE
Reduce the frequency of dependency updating

### DIFF
--- a/.github/workflows/update-nixpkgs.yml
+++ b/.github/workflows/update-nixpkgs.yml
@@ -1,10 +1,10 @@
-name: Update dependencies
+name: Update nixpkgs
 on:
   schedule:
-    - cron:  '0 20 * * 3'
+    - cron:  '0 20 3 * *'
 jobs:
   niv-updater:
-    name: 'Create PRs for niv-managed dependencies'
+    name: 'Create PRs for updating nixpkgs'
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action


### PR DESCRIPTION
Updating nixpkgs requires the rebuild of most of the derivations, which takes some time. I've changed the configuration to update it only once a month.